### PR TITLE
Page Scroll Fix

### DIFF
--- a/assets/css/rt-theme.css
+++ b/assets/css/rt-theme.css
@@ -2779,7 +2779,7 @@ body.admin-body {
 @media (max-width: 850px) {
   body.admin-body {
     padding-left: 0;
-    overflow: hidden; }
+    overflow-x: hidden; }
 
   #admin-wrap.active {
     position: relative;

--- a/assets/sass/_admin-page.scss
+++ b/assets/sass/_admin-page.scss
@@ -203,7 +203,7 @@ body.admin-body {
 
     body.admin-body {
         padding-left: 0;
-        overflow: hidden;
+        overflow-x: hidden;
     }
     
     #admin-wrap.active {


### PR DESCRIPTION
Fixed the overflow property on the body tag causing there to be no
vertical scroll. Changed it to overflow-x:hidden only.
